### PR TITLE
add .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,12 @@
+tests/
+bower_components/
+
+.travis.yml
+.npmignore
+Brocfile.js
+.editorconfig
+testem.json
+.ember-cli
+bower.json
+.bowerrc
+**/.gitkeep


### PR DESCRIPTION
prevent tests and other unnecessary files from being bundled into npm
module on 'npm pack'

What is your view on this issue? Should an ember-cli addon only contain the minimal set of files required or should it contain all files, including tests?