### PR TITLE
Fixing pluralization

### DIFF
--- a/addon/utils/t.js
+++ b/addon/utils/t.js
@@ -33,7 +33,7 @@ function T(attributes) {
     result = get(locale, read(path));
 
     if (Ember.typeOf(result) === 'object') {
-      rules = this.container.lookupFactory('ember-cli-i18n@rule:'+countryCode.split('-')[0])['default'];
+      rules = this.container.lookupFactory('ember-cli-i18n@rule:'+countryCode.split('-')[0]);
       var ruleResults = rules(values[0], result, path, countryCode);
       result = ruleResults.result;
       path = ruleResults.path;

--- a/tests/acceptance/t-test.js
+++ b/tests/acceptance/t-test.js
@@ -30,6 +30,15 @@ test('with bound arguments', function() {
   });
 });
 
+test('with pluralization', function() {
+  visit('/');
+
+  andThen(function() {
+    var span = find('span.three');
+    equal(span.text(), 'There are many people here');
+  });
+});
+
 test('changing application locale', function() {
   visit('/');
 

--- a/tests/dummy/app/locales/en.js
+++ b/tests/dummy/app/locales/en.js
@@ -1,4 +1,8 @@
 export default {
   foo: 'bar',
-  age: 'You are %@1 years old'
+  age: 'You are %@1 years old',
+  person: {
+    one: 'There is one person here',
+    other: 'There are many people here'
+  }
 };

--- a/tests/dummy/app/locales/es.js
+++ b/tests/dummy/app/locales/es.js
@@ -1,4 +1,8 @@
 export default {
   foo: 'es_bar',
-  age: 'es_You are %@1 years old'
+  age: 'es_You are %@1 years old',
+  person: {
+    one: 'es_There is one person here',
+    other: 'es_There are many people here'
+  }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -2,3 +2,4 @@
 
 <span class="one">{{t 'foo' count=colorCount}}</span>
 <span class="two">{{t 'age' age}}</span>
+<span class="three">{{t 'person' 2}}</span>

--- a/tests/unit/utils/t-test.js
+++ b/tests/unit/utils/t-test.js
@@ -79,7 +79,11 @@ module('t utility function', {
 
       splitName[1] = splitName[1] + 's';
 
-      return require(splitName.join('/'));
+      var module = require(splitName.join('/'));
+
+      if (module && module['default']) { module = module['default']; }
+
+      return module;
     };
 
     container.register('application:main', application, { instantiate: false });


### PR DESCRIPTION
Ember's `Container#lookupFactory` was returning the rule function not `{default: function(){}}`, which was causing this to break.  I verified this with an acceptance test in this project

Please take a look at the code that overrides `#lookupFactory` in the unit test. I'm not 100% sure how you guys intended that to work, but I kind of hacked it together to simulate the behavior I was seeing in `Container#lookupFactory`