### PR TITLE
Bound count arguments throw error

### DIFF
--- a/addon/rules/base.js
+++ b/addon/rules/base.js
@@ -1,11 +1,15 @@
 import Ember from 'ember';
+import { read } from 'ember-cli-i18n/utils/stream';
 
 export default function(keys, value, result, path, countryCode, fn) {
   var type;
 
+  // Handle results that come in as a Stream
+  value = read(value);
+
   if (hasValidKey(keys, result)) {
     if(Ember.typeOf(value) === 'number') {
-      type = fn(value);      
+      type = fn(value);
     } else {
       Ember.assert('Translation for key "' + path + '" expected a count value.', false);
     }
@@ -21,7 +25,7 @@ function hasValidKey(keys, result) {
 
   for(var i = 0; i < resultKeys.length; i++) {
     if (keys.indexOf(resultKeys[i]) > -1) {
-     return true; 
+     return true;
     }
   }
 

--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -37,6 +37,14 @@ export default function tHelper() {
     Ember.run.scheduleOnce('render', childView, 'rerender');
   }));
 
+  // bind any arguments that are Streams
+  for (var i = 0, l = args.length; i < l; i++) {
+    var param = args[i];
+    if(param && param.isStream){
+      param.subscribe(stream.notify, stream);
+    };
+  }
+
   application.localeStream.subscribe(stream.notify, stream);
 
   if (path.isStream) {

--- a/tests/acceptance/t-test.js
+++ b/tests/acceptance/t-test.js
@@ -39,6 +39,25 @@ test('with pluralization', function() {
   });
 });
 
+test('with pluralization updated from a stream', function(){
+  visit('/');
+
+  andThen(function(){
+    var span = find('span.four');
+    equal(span.text(), 'There is 1 dependent person here');
+  });
+
+  andThen(function(){
+    click('.add-dependent');
+  });
+
+  andThen(function(){
+    var span = find('span.four');
+    equal(span.text(), 'There are 2 dependent people here');
+  });
+
+});
+
 test('changing application locale', function() {
   visit('/');
 

--- a/tests/dummy/app/controllers/application.js
+++ b/tests/dummy/app/controllers/application.js
@@ -2,5 +2,12 @@ import Ember from 'ember';
 
 export default Ember.Controller.extend({
   age: 35,
-  colorCount: 2
+  colorCount: 2,
+  dependentPeopleCount: 1,
+  numDependentPeopleBinding: 'dependentPeopleCount',
+  actions: {
+    addDependentPerson: function(){
+      this.set('dependentPeopleCount', this.get('dependentPeopleCount') + 1);
+    }
+  }
 });

--- a/tests/dummy/app/locales/en.js
+++ b/tests/dummy/app/locales/en.js
@@ -4,5 +4,9 @@ export default {
   person: {
     one: 'There is one person here',
     other: 'There are many people here'
+  },
+  dependent_person: {
+    one: 'There is %@ dependent person here',
+    other: 'There are %@ dependent people here'
   }
 };

--- a/tests/dummy/app/locales/es.js
+++ b/tests/dummy/app/locales/es.js
@@ -4,5 +4,9 @@ export default {
   person: {
     one: 'es_There is one person here',
     other: 'es_There are many people here'
+  },
+  dependent_person: {
+    one: 'es_There is @% dependent person here',
+    other: 'es_There are @% dependent people here'
   }
 };

--- a/tests/dummy/app/templates/application.hbs
+++ b/tests/dummy/app/templates/application.hbs
@@ -3,3 +3,6 @@
 <span class="one">{{t 'foo' count=colorCount}}</span>
 <span class="two">{{t 'age' age}}</span>
 <span class="three">{{t 'person' 2}}</span>
+<span class="four">{{t 'dependent_person' numDependentPeople}}</span>
+
+<a class='add-dependent' {{action 'addDependentPerson'}}>Add Dependent Person</a>


### PR DESCRIPTION
This is the PR I referenced in #49

- Arguments that come in as Streams to the `rules()` function were throwing an error
- Bound arguments passed into the `t()` helper were not triggering an update of the parent Stream

These are really two related issues, so I can break it into two PRs if you prefer
