### PR TITLE
Make ember-i18n translations work

### DIFF
--- a/addon/utils/t.js
+++ b/addon/utils/t.js
@@ -32,6 +32,10 @@ function T(attributes) {
 
     result = get(locale, read(path));
 
+    if (!result){
+      result = locale[path];
+    }
+
     if (Ember.typeOf(result) === 'object') {
       rules = this.container.lookupFactory('ember-cli-i18n@rule:'+countryCode.split('-')[0]);
       var ruleResults = rules(values[0], result, path, countryCode);


### PR DESCRIPTION
Make translation keys like 'employees.name.last' work when side loaded from a flat structured JSON as you have them probably from ember-i18n