### PR TITLE
Modified to use the private registerHelper api

### DIFF
--- a/app/initializers/t.js
+++ b/app/initializers/t.js
@@ -4,7 +4,7 @@ import tHelper from '../helpers/t';
 import Stream from 'ember-cli-i18n/utils/stream';
 
 export function initialize(container, application) {
-  Ember.HTMLBars.registerHelper('t', tHelper);
+  Ember.HTMLBars._registerHelper('t', tHelper);
 
   application.localeStream = new Stream(function() {
     return  application.get('locale');


### PR DESCRIPTION
registerHelper is no more a public api in HTMLBars with this commit https://github.com/emberjs/ember.js/commit/ad62ccfdfd9578884261c96a2af4a6a238bd3ae9. Not sure what's the preferred approach to register a helper now with htmlbars.

//cc @rwjblue 