### PR TITLE
changed to use private registerHelper api

### DIFF
--- a/app/initializers/t.js
+++ b/app/initializers/t.js
@@ -4,7 +4,7 @@ import tHelper from '../helpers/t';
 import Stream from 'ember-cli-i18n/utils/stream';
 
 export function initialize(container, application) {
-  Ember.HTMLBars.registerHelper('t', tHelper);
+  Ember.HTMLBars._registerHelper('t', tHelper);
 
   application.localeStream = new Stream(function() {
     return  application.get('locale');

--- a/bower.json
+++ b/bower.json
@@ -3,7 +3,7 @@
   "dependencies": {
     "handlebars": "~2.0.0",
     "jquery": "^1.11.1",
-    "ember": "1.10.0-beta.4",
+    "ember": "1.10.0",
     "ember-data": "1.0.0-beta.14.1",
     "ember-resolver": "~0.1.10",
     "loader.js": "stefanpenner/loader.js#1.0.1",


### PR DESCRIPTION
registerHelper is no more a public api in HTMLBars with this commit emberjs/ember.js@ad62ccf. Not sure what's the preferred approach to register a helper now with htmlbars.

//cc @rwjblue