### PR TITLE
Use `view` from `env.data.view` instead of relying on `this`.

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -1,9 +1,10 @@
 import Stream from 'ember-cli-i18n/utils/stream';
 
 export default function tHelper(params, hash, options, env) {
+  var view = env.data.view;
   var path = params.shift();
 
-  var container = this.container;
+  var container = view.container;
   var t = container.lookup('utils:t');
   var application = container.lookup('application:main');
 


### PR DESCRIPTION
Helper's context will be `undefined` soon, in preparation for a larger refactoring of views + helpers that is hopefully going to land in Ember 1.12.

This PR makes sure that ember-cli-18n will function after that change.  `env.data.view` has been available since 1.10.0-beta.1, so this is safe for all HTMLBars Ember versions.