### PR TITLE
update README with how to add tranlation key to a component

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ If the value has interpolation keys you can pass those values:
 {{t colors colorOne colorTwo}}
 ```
 
+Passing localisation key to a component template:
+
+```handlebars
+{{x-toggle on=(t 'toggle.labels.on') off=(t 'toggle.labels.off')}}
+```
+
 #### Utility
 
 The `t` function can be used outside of templates as a utility function:


### PR DESCRIPTION
I Googled a lot, tried many things, created custom helpers until I found out it was as easy as:

```
{{x-toggle on=(t 'toggle.labels.on') off=(t 'toggle.labels.off')}}
```
It would have saved me some time if it would be specified in the docs, therefore...