### PR TITLE
support html tags in translations

### DIFF
--- a/addon/utils/t.js
+++ b/addon/utils/t.js
@@ -13,6 +13,8 @@ function T(attributes) {
     var service = this.container.lookupFactory('service:i18n');
     var result;
     var locale;
+    var application = this.container.lookup('application:main');
+    var htmlLocales = application.htmlLocales ? true : false;
 
     if (!Ember.isArray(values)) {
       values = Array.prototype.slice.call(arguments, 1);
@@ -31,7 +33,14 @@ function T(attributes) {
     Ember.assert('Missing translation for key "' + path + '".', result);
     Ember.assert('Translation for key "' + path + '" is not a string.', Ember.typeOf(result) === 'string');
 
-    return service.fmt(result, readArray(values));
+    result = service.fmt(result, readArray(values));
+
+    if( htmlLocales !== true ) {
+      return result;
+    }
+    else {
+      return Ember.String.htmlSafe( result );
+    } 
   };
 }
 

--- a/tests/unit/utils/t-test.js
+++ b/tests/unit/utils/t-test.js
@@ -235,3 +235,20 @@ test('can override the format handler', function(assert) {
 
   assert.equal(t('foo'), 'barbiz');
 });
+
+test('escapes html as default', function(assert) {
+  application.defaultLocale = 'en';
+  
+  assert.equal(typeof t('foo'), 'string');
+
+  application.htmlLocales = false;
+  
+  assert.equal(typeof t('foo'), 'string');
+});
+
+test('allow html in locales', function(assert) {
+  application.defaultLocale = 'en';
+  application.htmlLocales = true;
+
+  assert.equal(typeof t('foo'), 'object');
+});


### PR DESCRIPTION
Adding support for html tags in translation as it was discussed in #97. It's disabled by default as it could be a security risk. Could be enabled by configuration:

```
var ENV = {
  APP: {
    defaultLocale: 'en',
    htmlLocales: true
  }
};
```