### PR TITLE
add test-support for default locale

### DIFF
--- a/test-support/ember-cli-i18n-test.js
+++ b/test-support/ember-cli-i18n-test.js
@@ -24,6 +24,11 @@ if (window.QUnit) {
     }
   });
 
+  test('default locale exists', function(assert) {
+    assert.ok(Ember.isPresent(config.APP.defaultLocale, 'default locale is defined'));
+    assert.ok(typeof defaultLocale === 'object', 'default locale exist');
+  });
+
   test('locales all contain the same keys', function(assert) {
     var knownLocales = keys(locales);
     if (knownLocales.length === 1) {


### PR DESCRIPTION
Add test-support for default locale. Checks that defaultLocale is defined in App configuration and that it exists.