### PR TITLE
Fix helper error on Ember 1.13.0

### DIFF
--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -1,7 +1,7 @@
 import Stream from 'ember-cli-i18n/utils/stream';
 
 export default function tHelper(params, hash, options, env) {
-  var view = env.data.view;
+  var view = env.view;
   var path = params.shift();
 
   var container = view.container;

--- a/app/helpers/t.js
+++ b/app/helpers/t.js
@@ -1,7 +1,7 @@
 import Stream from 'ember-cli-i18n/utils/stream';
 
 export default function tHelper(params, hash, options, env) {
-  var view = env.view;
+  var view = env.view || env.data.view;
   var path = params.shift();
 
   var container = view.container;


### PR DESCRIPTION
I am not sure how are you dealing with handling different ember versions, but I am using this addon and after update to Ember 1.13.0 I got this error:

![screenshot 2015-06-15 14 22 08](https://cloud.githubusercontent.com/assets/431926/8168660/ee17e132-1369-11e5-9ebd-cb5d9a4a0dbf.png)

I played a little in the console and I found that `view` is now inside `env`. So I did this little change to make it work in my project.

Now it can work with the two versions, the problem is that I don't know how to test this because (as far as I understand) this function is just tested with acceptance tests and I am not sure how to handle another ember version. I think that a test is necessary because the reason of the change is not clear for someone that is just watching the helper code.

Well... hope it helps =)